### PR TITLE
obfuscate auth header

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -11,3 +11,4 @@ pub mod ratelimit;
 pub mod routing;
 pub mod stats;
 pub mod tokenizer;
+pub mod pii;

--- a/crates/common/src/pii.rs
+++ b/crates/common/src/pii.rs
@@ -20,6 +20,25 @@ mod test {
     pub fn test_obfuscate_auth_header() {
         let mut headers = vec![("Authorization".to_string(), "Bearer 1234".to_string())];
         obfuscate_auth_header(&mut headers);
-        assert_eq!(headers, vec![("Authorization".to_string(), "Bearer ***".to_string())]);
+        assert_eq!(
+            headers,
+            vec![("Authorization".to_string(), "Bearer ***".to_string())]
+        );
+    }
+
+    #[test]
+    pub fn test_obfuscate_no_auth_header_found() {
+        let mut headers = vec![
+            (":path".to_string(), "/healthz".to_string()),
+            (":method".to_string(), "POST".to_string()),
+        ];
+        obfuscate_auth_header(&mut headers);
+        assert_eq!(
+            headers,
+            vec![
+                (":path".to_string(), "/healthz".to_string()),
+                (":method".to_string(), "POST".to_string()),
+            ]
+        );
     }
 }

--- a/crates/common/src/pii.rs
+++ b/crates/common/src/pii.rs
@@ -1,0 +1,25 @@
+pub fn obfuscate_auth_header(headers: &mut [(String, String)]) -> &[(String, String)] {
+    headers.iter_mut().for_each(|(key, value)| {
+        if key.to_lowercase() == "authorization" {
+            if value.starts_with("Bearer ") {
+                *value = "Bearer ***".to_string();
+            } else {
+                *value = "***".to_string();
+            }
+        }
+    });
+
+    headers
+}
+
+#[cfg(test)]
+mod test {
+    use crate::pii::obfuscate_auth_header;
+
+    #[test]
+    pub fn test_obfuscate_auth_header() {
+        let mut headers = vec![("Authorization".to_string(), "Bearer 1234".to_string())];
+        obfuscate_auth_header(&mut headers);
+        assert_eq!(headers, vec![("Authorization".to_string(), "Bearer ***".to_string())]);
+    }
+}

--- a/crates/llm_gateway/src/stream_context.rs
+++ b/crates/llm_gateway/src/stream_context.rs
@@ -10,6 +10,7 @@ use common::consts::{
 };
 use common::errors::ServerError;
 use common::llm_providers::LlmProviders;
+use common::pii::obfuscate_auth_header;
 use common::ratelimit::Header;
 use common::{ratelimit, routing, tokenizer};
 use http::StatusCode;
@@ -153,7 +154,7 @@ impl HttpContext for StreamContext {
         debug!(
             "on_http_request_headers S[{}] req_headers={:?}",
             self.context_id,
-            self.get_http_request_headers()
+            obfuscate_auth_header(&mut self.get_http_request_headers())
         );
 
         self.request_id = self.get_http_request_header(REQUEST_ID_HEADER);

--- a/crates/prompt_gateway/src/http_context.rs
+++ b/crates/prompt_gateway/src/http_context.rs
@@ -13,7 +13,7 @@ use common::{
         HEALTHZ_PATH, REQUEST_ID_HEADER, TOOL_ROLE, TRACE_PARENT_HEADER, USER_ROLE,
     },
     errors::ServerError,
-    http::{CallArgs, Client},
+    http::{CallArgs, Client}, pii::obfuscate_auth_header,
 };
 use http::StatusCode;
 use log::{debug, trace, warn};
@@ -48,7 +48,7 @@ impl HttpContext for StreamContext {
         trace!(
             "on_http_request_headers S[{}] req_headers={:?}",
             self.context_id,
-            self.get_http_request_headers()
+            obfuscate_auth_header(&mut self.get_http_request_headers())
         );
 
         self.request_id = self.get_http_request_header(REQUEST_ID_HEADER);


### PR DESCRIPTION
fixes https://github.com/katanemo/arch/issues/234

now log line should look like this
```
archgw-1  | [2024-11-08 07:29:15.598][39] ... req_headers=[... ("authorization", "Bearer ***") ...]
```