### PR TITLE
update rust toolchain to 1.82

### DIFF
--- a/.github/workflows/rust_tests.yml
+++ b/.github/workflows/rust_tests.yml
@@ -18,13 +18,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup | Rust
-        run: rustup toolchain install stable --profile minimal
+        run: rustup toolchain install 1.82 --profile minimal
 
       - name: Setup | Install wasm toolchain
-        run: rustup target add wasm32-wasi
+        run: rustup target add wasm32-wasip1
 
       - name: Build wasm module
-        run: cargo build --release --target=wasm32-wasi
+        run: cargo build --release --target=wasm32-wasip1
 
       - name: Run unit tests
         run: cargo test --lib

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -1,22 +1,22 @@
 # build filter using rust toolchain
-FROM rust:1.80.0 as builder
-RUN rustup -v target add wasm32-wasi
+FROM rust:1.82.0 as builder
+RUN rustup -v target add wasm32-wasip1
 WORKDIR /arch
 COPY crates .
 
-RUN cd prompt_gateway && cargo build --release --target wasm32-wasi
-RUN cd llm_gateway && cargo build --release --target wasm32-wasi
+RUN cd prompt_gateway && cargo build --release --target wasm32-wasip1
+RUN cd llm_gateway && cargo build --release --target wasm32-wasip1
 
 # copy built filter into envoy image
-FROM envoyproxy/envoy:v1.31-latest as envoy
+FROM envoyproxy/envoy:v1.32-latest as envoy
 
 #Build config generator, so that we have a single build image for both Rust and Python
-FROM python:3-slim as arch
+FROM python:3.13-slim as arch
 
 RUN apt-get update && apt-get install -y gettext-base curl && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /arch/target/wasm32-wasi/release/prompt_gateway.wasm /etc/envoy/proxy-wasm-plugins/prompt_gateway.wasm
-COPY --from=builder /arch/target/wasm32-wasi/release/llm_gateway.wasm /etc/envoy/proxy-wasm-plugins/llm_gateway.wasm
+COPY --from=builder /arch/target/wasm32-wasip1/release/prompt_gateway.wasm /etc/envoy/proxy-wasm-plugins/prompt_gateway.wasm
+COPY --from=builder /arch/target/wasm32-wasip1/release/llm_gateway.wasm /etc/envoy/proxy-wasm-plugins/llm_gateway.wasm
 COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
 WORKDIR /config
 COPY arch/requirements.txt .

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -11,7 +11,7 @@ RUN cd llm_gateway && cargo build --release --target wasm32-wasip1
 FROM envoyproxy/envoy:v1.32-latest as envoy
 
 #Build config generator, so that we have a single build image for both Rust and Python
-FROM python:3.13-slim as arch
+FROM python:3.12-slim as arch
 
 RUN apt-get update && apt-get install -y gettext-base curl && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/arch/README.md
+++ b/arch/README.md
@@ -3,13 +3,13 @@
 ## Add toolchain
 
 ```sh
-$ rustup target add wasm32-wasi
+$ rustup target add wasm32-wasip1
 ```
 
 ## Building
 
 ```sh
-$ cargo build --target wasm32-wasi --release
+$ cargo build --target wasm32-wasip1 --release
 ```
 
 ## Testing
@@ -25,7 +25,7 @@ $ cargo test
 
 - Build filter binary,
   ```
-  $ cargo build --target wasm32-wasi --release
+  $ cargo build --target wasm32-wasip1 --release
   ```
 - Start envoy with arch_config.yaml and test,
   ```

--- a/arch/docker-compose.dev.yaml
+++ b/arch/docker-compose.dev.yaml
@@ -13,8 +13,8 @@ services:
       - ./envoy.template.yaml:/config/envoy.template.yaml
       - ./arch_config_schema.yaml:/config/arch_config_schema.yaml
       - ./tools/cli/config_generator.py:/config/config_generator.py
-      - ../crates/target/wasm32-wasi/release/llm_gateway.wasm:/etc/envoy/proxy-wasm-plugins/llm_gateway.wasm
-      - ../crates/target/wasm32-wasi/release/prompt_gateway.wasm:/etc/envoy/proxy-wasm-plugins/prompt_gateway.wasm
+      - ../crates/target/wasm32-wasip1/release/llm_gateway.wasm:/etc/envoy/proxy-wasm-plugins/llm_gateway.wasm
+      - ../crates/target/wasm32-wasip1/release/prompt_gateway.wasm:/etc/envoy/proxy-wasm-plugins/prompt_gateway.wasm
       - ~/archgw_logs:/var/log/
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/crates/llm_gateway/tests/integration.rs
+++ b/crates/llm_gateway/tests/integration.rs
@@ -7,10 +7,10 @@ use serial_test::serial;
 use std::path::Path;
 
 fn wasm_module() -> String {
-    let wasm_file = Path::new("../target/wasm32-wasi/release/llm_gateway.wasm");
+    let wasm_file = Path::new("../target/wasm32-wasip1/release/llm_gateway.wasm");
     assert!(
         wasm_file.exists(),
-        "Run `cargo build --release --target=wasm32-wasi` first"
+        "Run `cargo build --release --target=wasm32-wasip1` first"
     );
     wasm_file.to_str().unwrap().to_string()
 }

--- a/crates/prompt_gateway/tests/integration.rs
+++ b/crates/prompt_gateway/tests/integration.rs
@@ -17,10 +17,10 @@ use std::collections::HashMap;
 use std::path::Path;
 
 fn wasm_module() -> String {
-    let wasm_file = Path::new("../target/wasm32-wasi/release/prompt_gateway.wasm");
+    let wasm_file = Path::new("../target/wasm32-wasip1/release/prompt_gateway.wasm");
     assert!(
         wasm_file.exists(),
-        "Run `cargo build --release --target=wasm32-wasi` first"
+        "Run `cargo build --release --target=wasm32-wasip1` first"
     );
     wasm_file.to_str().unwrap().to_string()
 }

--- a/demos/hr_agent/Dockerfile
+++ b/demos/hr_agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10 AS base
+FROM python:3.12 AS base
 
 FROM base AS builder
 
@@ -7,7 +7,7 @@ WORKDIR /src
 COPY requirements.txt /src/
 RUN pip install --prefix=/runtime --force-reinstall -r requirements.txt
 
-FROM python:3.10-slim AS output
+FROM python:3.12-slim AS output
 COPY --from=builder /runtime /usr/local
 
 WORKDIR /app

--- a/demos/network_agent/Dockerfile
+++ b/demos/network_agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10 AS base
+FROM python:3.12 AS base
 
 FROM base AS builder
 
@@ -9,7 +9,7 @@ RUN pip install --prefix=/runtime --force-reinstall -r requirements.txt
 
 COPY . /src
 
-FROM python:3.10-slim AS output
+FROM python:3.12-slim AS output
 
 COPY --from=builder /runtime /usr/local
 

--- a/demos/shared/chatbot_ui/Dockerfile
+++ b/demos/shared/chatbot_ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10 AS base
+FROM python:3.12 AS base
 
 FROM base AS builder
 
@@ -8,7 +8,7 @@ COPY requirements.txt /src/
 
 RUN pip install --prefix=/runtime --force-reinstall -r requirements.txt
 
-FROM python:3.10-slim AS output
+FROM python:3.12-slim AS output
 
 COPY --from=builder /runtime /usr/local
 

--- a/model_server/Dockerfile
+++ b/model_server/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.10 AS builder
+FROM python:3.12 AS builder
 
 COPY requirements.txt .
 RUN pip install --prefix=/runtime -r requirements.txt
 
-FROM python:3.10-slim AS output
+FROM python:3.12-slim AS output
 
 # curl is needed for health check in docker-compose
 RUN apt-get update && apt-get install -y curl && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
wasm-wasi32 target is deprated and will be removed in rust 1.84. Updating our build system to use wasm-wasi32p1 which is the recommendation. See [here for detail](https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html).

Also update envoy to 1.32 and python to 3.12.