### PR TITLE
removing hard depdency on mistral keys in weather forecast demos

### DIFF
--- a/demos/weather_forecast/arch_config.yaml
+++ b/demos/weather_forecast/arch_config.yaml
@@ -32,11 +32,6 @@ llm_providers:
     provider: openai
     model: gpt-4o
 
-  - name: ministral-3b
-    access_key: $MISTRAL_API_KEY
-    provider: mistral
-    model: ministral-3b-latest
-
 system_prompt: |
   You are a helpful assistant.
 

--- a/demos/weather_forecast_signoz/arch_config.yaml
+++ b/demos/weather_forecast_signoz/arch_config.yaml
@@ -32,11 +32,6 @@ llm_providers:
     provider: openai
     model: gpt-4o
 
-  - name: ministral-3b
-    access_key: $MISTRAL_API_KEY
-    provider: mistral
-    model: ministral-3b-latest
-
 system_prompt: |
   You are a helpful assistant.
 


### PR DESCRIPTION
mistral keys shouldn't really exist in the weather forecast demos.